### PR TITLE
adds support to microcode files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "systemd-boot-gen"
 version = "1.1.1"
 edition = "2018"
-authors = ["Paul Alesius <paul@unnservice.com>"]
+authors = ["Paul Alesius <paul@unnservice.com>", "Rafael Delgado Martins <rafael@delgadomartins.com>"]
 repository = "https://github.com/unnservice/systemd-boot-gen"
 license = "GPL-3.0-or-later"
 description = "systemd-boot boot configuration generator"

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,7 @@ pub struct Entry {
     pub title: String,
     pub version: String,
     pub linux: String,
+    pub microcode: Option<String>,
     pub initrd: String,
     pub options: String,
 }
@@ -48,11 +49,22 @@ impl Kernel {
     }
 }
 
-pub fn kernel_to_entry(machineid: &str, osname: &str, cmdline: &str, kernel: &Kernel) -> Entry {
+pub fn kernel_to_entry(
+    machineid: &str,
+    osname: &str,
+    cmdline: &str,
+    microcodefile: Option<&str>,
+    kernel: &Kernel,
+) -> Entry {
     let name = format!("{}-{}.conf", machineid, kernel.version);
     let title = format!("title {} ({})", osname, kernel.version);
     let version = format!("version {}", kernel.version);
     let linux = format!("linux /vmlinuz-{}", kernel.version);
+    let microcode = if microcodefile.is_some() {
+        Some(format!("initrd /{}", microcodefile.unwrap().trim()))
+    } else {
+        None
+    };
     let initrd = format!("initrd /initramfs-{}.img", kernel.version);
     let options = format!("options {}", cmdline);
 
@@ -61,6 +73,7 @@ pub fn kernel_to_entry(machineid: &str, osname: &str, cmdline: &str, kernel: &Ke
         title,
         version,
         linux,
+        microcode,
         initrd,
         options,
     }


### PR DESCRIPTION
Now the users can choose a microcode file to adds to the entries.

The usability stays the same, so no one will be affected by the implementation.